### PR TITLE
sepolicy_vndr: legacy: Fix location_app neverallow

### DIFF
--- a/legacy/vendor/common/file.te
+++ b/legacy/vendor/common/file.te
@@ -235,7 +235,7 @@ type qfp-daemon_data_file, file_type, data_file_type;
 type persist_qti_fp_file, file_type, vendor_persist_type;
 
 # imshelper_app file types
-type imshelper_app_data_file, file_type, data_file_type;
+type imshelper_app_data_file, file_type, app_data_file_type, data_file_type;
 
 # RIDL data files
 type RIDL_data_file, file_type, data_file_type;

--- a/legacy/vendor/common/location_app.te
+++ b/legacy/vendor/common/location_app.te
@@ -26,7 +26,6 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 hal_client_domain(vendor_location_app, hal_perf)
-qmux_socket(vendor_location_app)
 
 #Permissions for JDWP
 userdebug_or_eng(`

--- a/legacy/vendor/common/recovery.te
+++ b/legacy/vendor/common/recovery.te
@@ -50,6 +50,5 @@ recovery_only(`
     # Enable adb on configfs devices
     allow recovery configfs:file rw_file_perms;
     allow recovery configfs:dir rw_dir_perms;
-    set_prop(recovery, ffs_prop);
     get_prop(recovery, vendor_boot_mode_prop)
 ')


### PR DESCRIPTION
libsepol.report_failure: neverallow on line 773 of system/sepolicy/public/domain.te (or line 13438 of policy.conf) violated by allow vendor_location_app qmuxd_socket:sock_file { create setattr unlink };
libsepol.report_failure: neverallow on line 730 of system/sepolicy/public/domain.te (or line 13349 of policy.conf) violated by allow vendor_location_app qmuxd:unix_stream_socket { connectto };
libsepol.check_assertions: 2 neverallow failures occurred
Error while expanding policy