### PR TITLE
sepolicy_vndr: qva: Allow vendor_cnd to read wifi_hal_prop

### DIFF
--- a/qva/vendor/common/cnd.te
+++ b/qva/vendor/common/cnd.te
@@ -45,6 +45,9 @@ allow vendor_cnd self:{
 allow vendor_cnd vendor_wifi_vendor_data_file:dir r_dir_perms;
 allow vendor_cnd vendor_wifi_vendor_wpa_socket:sock_file write;
 
+# allow vendor_cnd to read wifi_hal_prop
+get_prop(vendor_cnd, wifi_hal_prop)
+
 #allow vendor_cnd daemon to invoke hostapd_cli
 allow vendor_cnd vendor_shell_exec:file rx_file_perms;
 domain_auto_trans(vendor_cnd, vendor_hostapd_exec, vendor_hostapd)


### PR DESCRIPTION
W libc    : Access denied finding property "wifi.interface"
W cnd     : type=1400 audit(0.0:22): avc: denied { read } for name="u:object_r:wifi_hal_prop:s0" dev="tmpfs" ino=26257 scontext=u:r:vendor_cnd:s0 tcontext=u:object_r:wifi_hal_prop:s0 tclass=file permissive=0

Change-Id: I6cf8ad4133ca3013d844d4ef3b2701de22f408b0